### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Build Tests
+permissions:
+  contents: read
 
 on:
   # push:


### PR DESCRIPTION
Potential fix for [https://github.com/FirmwareDroid/FirmwareDroid/security/code-scanning/5](https://github.com/FirmwareDroid/FirmwareDroid/security/code-scanning/5)

The fix is to add an explicit `permissions` block with the minimal permissions needed for the job(s) in the workflow. For build/test workflows that only need to check out code and install dependencies, `contents: read` is usually sufficient. This can be placed at the workflow root (to apply to all jobs), or on the single job. The best practice is to add it at the root just beneath the `name:` field for global effect. No imports or definitions are required, just a YAML property addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
